### PR TITLE
Fix crash with trinkets

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.6-SNAPSHOT'
+    id 'fabric-loom' version '1.7.2'
     id 'maven-publish'
     id "com.modrinth.minotaur" version "2.4.3"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,8 +13,8 @@ trinkets_version=3.7.0
 cardinal_components_version=6.0.0-beta.3
 
 #malilib
-malilib_version = 0.18.999-sakura
-minecraft_version_out = 1.21-rc1
+malilib_version = 0.20.0
+minecraft_version_out = 1.21
 
 # Mod Properties
 mod_version=1.21-1.11.0

--- a/src/main/java/de/guntram/mcmod/durabilityviewer/client/gui/GuiItemDurability.java
+++ b/src/main/java/de/guntram/mcmod/durabilityviewer/client/gui/GuiItemDurability.java
@@ -36,6 +36,7 @@ import org.joml.Matrix4fStack;
 import team.reborn.energy.EnergyHolder;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -183,6 +184,9 @@ public class GuiItemDurability {
         ItemIndicator[] trinkets;
         if (haveTrinketsApi) {
             List<ItemStack> equipped = getTrinkets(player);
+            if (equipped == null) {
+                equipped = Collections.emptyList();
+            }
 
             trinkets = new ItemIndicator[equipped.size()];
             if (trinkets.length > trinketWarners.length) {


### PR DESCRIPTION
If `getTrinkets` returns null, replace the result with `Collections.emptyList()`